### PR TITLE
Working example of nested colors (issue #6)

### DIFF
--- a/src/ConsoleExtensions.cs
+++ b/src/ConsoleExtensions.cs
@@ -1,16 +1,18 @@
 ﻿namespace Pastel
 {
     using System;
+    using System.Collections.Generic;
     using System.Drawing;
     using System.Globalization;
+    using System.Linq;
     using System.Runtime.InteropServices;
-
+    using System.Text.RegularExpressions;
 
     public static class ConsoleExtensions
     {
-        private const int  STD_OUTPUT_HANDLE                     = -11;
+        private const int STD_OUTPUT_HANDLE = -11;
         private const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
-        private const uint DISABLE_NEWLINE_AUTO_RETURN        = 0x0008;
+        private const uint DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
 
         [DllImport("kernel32.dll")]
         private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
@@ -24,35 +26,62 @@
         [DllImport("kernel32.dll")]
         public static extern uint GetLastError();
 
+        private delegate string ColorFormatOriginal(string input, Color color);
+        private delegate string ColorFormatHexOriginal(string input, string hexColor);
+        private delegate string ColorFormat(FormattableString input, Color color);
+        private delegate string ColorFormatHex(FormattableString input, string hexColor);
 
-        private delegate string ColorFormat(   string input, Color     color);
-        private delegate string ColorFormatHex(string input, string hexColor);
 
-
-        private const string _formatString       = "\u001b[{0};2;{1};{2};{3}m{4}\u001b[0m";
+        private const string _formatString = "\u001b[{0};2;{1};{2};{3}m{4}\u001b[0m";
         private const string _foregroundModifier = "38";
         private const string _backgroundModifier = "48";
 
 
         private static readonly Func<string, int> _parseHexColor = hc => int.Parse(hc.Replace("#", ""), NumberStyles.HexNumber);
 
-        private static readonly Func<string,  Color, string, string> _colorFormat    = (s, c, f) => string.Format(_formatString, f, c.R, c.G, c.B, s);
-        private static readonly Func<string, string, string, string> _colorHexFormat = (s, c, f) => _colorFormat(s, Color.FromArgb(_parseHexColor(c)), f);
 
-        private static readonly ColorFormat    _noColorOutputFormat    = (s, _) => s;
-        private static readonly ColorFormatHex _noColorOutputHexFormat = (s, _) => s;
+        private static readonly Func<string, Color, string, string> _colorFormatOriginal = (s, c, f) =>
+        {
+            return string.Format(_formatString, f, c.R, c.G, c.B, s);
+        };
+        private static readonly Func<string, string, string, string> _colorHexFormatOriginal = (s, c, f) => _colorFormatOriginal(s, Color.FromArgb(_parseHexColor(c)), f);
 
-        private static readonly ColorFormat    _foregroundColorFormat    = (s, c) => _colorFormat(   s, c, _foregroundModifier);
+        private static readonly Func<FormattableString, Color, string, string> _colorFormat = (s, c, f) =>
+        {
+            var ss = Split(s.Format).Select(x => x.shouldFormat ? _colorFormatOriginal(x.s, c, f) : x.s).ToList();
+            return string.Format(string.Join("", ss), s.GetArguments());
+        };
+        private static readonly Func<FormattableString, string, string, string> _colorHexFormat = (s, c, f) => _colorFormat(s, Color.FromArgb(_parseHexColor(c)), f);
+
+        private static readonly ColorFormat _noColorOutputFormat = (s, _) => s.ToString();
+        private static readonly ColorFormatHex _noColorOutputHexFormat = (s, _) => s.ToString();
+
+        private static readonly ColorFormat _foregroundColorFormat = (s, c) => _colorFormat(s, c, _foregroundModifier);
         private static readonly ColorFormatHex _foregroundColorHexFormat = (s, c) => _colorHexFormat(s, c, _foregroundModifier);
 
-        private static readonly ColorFormat    _backgroundColorFormat    = (s, c) => _colorFormat(   s, c, _backgroundModifier);
+        private static readonly ColorFormat _backgroundColorFormat = (s, c) => _colorFormat(s, c, _backgroundModifier);
         private static readonly ColorFormatHex _backgroundColorHexFormat = (s, c) => _colorHexFormat(s, c, _backgroundModifier);
 
 
-        private static ColorFormat    _foregroundColorFormatFunc;
+        private static readonly ColorFormatOriginal _noColorOutputFormatOriginal = (s, _) => s;
+        private static readonly ColorFormatHexOriginal _noColorOutputHexFormatOriginal = (s, _) => s;
+
+        private static readonly ColorFormatOriginal _foregroundColorFormatOriginal = (s, c) => _colorFormatOriginal(s, c, _foregroundModifier);
+        private static readonly ColorFormatHexOriginal _foregroundColorHexFormatOriginal = (s, c) => _colorHexFormatOriginal(s, c, _foregroundModifier);
+
+        private static readonly ColorFormatOriginal _backgroundColorFormatOriginal = (s, c) => _colorFormatOriginal(s, c, _backgroundModifier);
+        private static readonly ColorFormatHexOriginal _backgroundColorHexFormatOriginal = (s, c) => _colorHexFormatOriginal(s, c, _backgroundModifier);
+
+        private static ColorFormatOriginal _foregroundColorFormatFuncOriginal;
+        private static ColorFormatHexOriginal _foregroundColorHexFormatFuncOriginal;
+
+        private static ColorFormatOriginal _backgroundColorFormatFuncOriginal;
+        private static ColorFormatHexOriginal _backgroundColorHexFormatFuncOriginal;
+
+        private static ColorFormat _foregroundColorFormatFunc;
         private static ColorFormatHex _foregroundColorHexFormatFunc;
 
-        private static ColorFormat    _backgroundColorFormatFunc;
+        private static ColorFormat _backgroundColorFormatFunc;
         private static ColorFormatHex _backgroundColorHexFormatFunc;
 
 
@@ -60,9 +89,9 @@
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var iStdOut =   GetStdHandle(STD_OUTPUT_HANDLE);
+                var iStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
 
-                var enable  =   GetConsoleMode(iStdOut, out var outConsoleMode)
+                var enable = GetConsoleMode(iStdOut, out var outConsoleMode)
                              && SetConsoleMode(iStdOut, outConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN);
             }
 
@@ -78,7 +107,7 @@
         }
 
 
-        
+
 
 
 
@@ -88,11 +117,17 @@
         /// </summary>
         public static void Enable()
         {
-            _foregroundColorFormatFunc    = _foregroundColorFormat;
+            _foregroundColorFormatFunc = _foregroundColorFormat;
             _foregroundColorHexFormatFunc = _foregroundColorHexFormat;
 
-            _backgroundColorFormatFunc    = _backgroundColorFormat;
+            _backgroundColorFormatFunc = _backgroundColorFormat;
             _backgroundColorHexFormatFunc = _backgroundColorHexFormat;
+
+            _foregroundColorFormatFuncOriginal = _foregroundColorFormatOriginal;
+            _foregroundColorHexFormatFuncOriginal = _foregroundColorHexFormatOriginal;
+
+            _backgroundColorFormatFuncOriginal = _backgroundColorFormatOriginal;
+            _backgroundColorHexFormatFuncOriginal = _backgroundColorHexFormatOriginal;
         }
 
         /// <summary>
@@ -100,11 +135,17 @@
         /// </summary>
         public static void Disable()
         {
-            _foregroundColorFormatFunc    = _noColorOutputFormat;
+            _foregroundColorFormatFunc = _noColorOutputFormat;
             _foregroundColorHexFormatFunc = _noColorOutputHexFormat;
 
-            _backgroundColorFormatFunc    = _noColorOutputFormat;
+            _backgroundColorFormatFunc = _noColorOutputFormat;
             _backgroundColorHexFormatFunc = _noColorOutputHexFormat;
+
+            _foregroundColorFormatFuncOriginal = _noColorOutputFormatOriginal;
+            _foregroundColorHexFormatFuncOriginal = _noColorOutputHexFormatOriginal;
+
+            _backgroundColorFormatFuncOriginal = _noColorOutputFormatOriginal;
+            _backgroundColorHexFormatFuncOriginal = _noColorOutputHexFormatOriginal;
         }
 
 
@@ -113,19 +154,29 @@
         /// </summary>
         /// <param name="input">The string to color.</param>
         /// <param name="color">The color to use on the specified string.</param>
-        public static string Pastel(this string input, Color color)
+        public static string Pastel(this Color color, FormattableString input)
         {
             return _foregroundColorFormatFunc(input, color);
         }
 
+        public static string Pastel(this string input, Color color)
+        {
+            return _foregroundColorFormatFuncOriginal(input, color);
+        }
+
         /// <summary>
         /// Returns a string wrapped in an ANSI foreground color code using the specified color.
         /// </summary>
         /// <param name="input">The string to color.</param>
         /// <param name="hexColor">The color to use on the specified string.<para>Supported format: [#]RRGGBB.</para></param>
-        public static string Pastel(this string input, string hexColor)
+        public static string Pastel(this string hexColor, FormattableString input)
         {
             return _foregroundColorHexFormatFunc(input, hexColor);
+        }
+
+        public static string Pastel(this string input, string hexColor)
+        {
+            return _foregroundColorHexFormatFuncOriginal(input, hexColor);
         }
 
 
@@ -135,9 +186,14 @@
         /// </summary>
         /// <param name="input">The string to color.</param>
         /// <param name="color">The color to use on the specified string.</param>
-        public static string PastelBg(this string input, Color color)
+        public static string PastelBg(this Color color, FormattableString input)
         {
             return _backgroundColorFormatFunc(input, color);
+        }
+
+        public static string PastelBg(this string input, Color color)
+        {
+            return _backgroundColorFormatFuncOriginal(input, color);
         }
 
         /// <summary>
@@ -145,9 +201,37 @@
         /// </summary>
         /// <param name="input">The string to color.</param>
         /// <param name="hexColor">The color to use on the specified string.<para>Supported format: [#]RRGGBB.</para></param>
-        public static string PastelBg(this string input, string hexColor)
+        public static string PastelBg(this string hexColor, FormattableString input)
         {
             return _backgroundColorHexFormatFunc(input, hexColor);
+        }
+
+        public static string PastelBg(this string input, string hexColor)
+        {
+            return _backgroundColorHexFormatFuncOriginal(input, hexColor);
+        }
+
+        private static List<(string s, bool shouldFormat)> Split(string input)
+        {
+
+            var values = new List<(string, bool)>();
+            int pos = 0;
+            foreach (Match m in Regex.Matches(input, @"\{\d*\}"))
+            {
+                var v = input.Substring(pos, m.Index - pos);
+                if (!string.IsNullOrEmpty(v))
+                {
+                    values.Add((input.Substring(pos, m.Index - pos), true));
+                }
+                values.Add((m.Value, false));
+                pos = m.Index + m.Length;
+            }
+            var vEnd = input.Substring(pos);
+            if (!string.IsNullOrEmpty(vEnd))
+            {
+                values.Add((vEnd, true));
+            }
+            return values;
         }
     }
 }

--- a/tests/Pastel.Tests/ColorTests.cs
+++ b/tests/Pastel.Tests/ColorTests.cs
@@ -279,5 +279,17 @@ namespace Pastel.Tests
                 ColorOutputEnabledTest();
             }
         }
+
+        [Fact]
+        public void NestedColors()
+        {
+            int red1 = 1, green1 = 1, blue1 = 1;
+            int red2 = 2, green2 = 2, blue2 = 2;
+            string expected = $"{"a".Pastel(Color.FromArgb(red1, green1, blue1))}{"b".Pastel(Color.FromArgb(red2, green2, blue2))}{"c".Pastel(Color.FromArgb(red1, green1, blue1))}";
+            string actual = Color.FromArgb(red1, green1, blue1).Pastel($"a{"b".Pastel(Color.FromArgb(red2, green2, blue2))}c");
+
+
+            Assert.Equal(expected, actual); 
+        }
     }
 }


### PR DESCRIPTION
an example how FormattableString could be used to make nested Pastels work.
Unfortunately, this could not be implemented as extension methods, because you can't really have extension methods on FormattableString. :(

This PR is not intended to "look good" yet... it's just a working example of how #6 could be fixed.

```
Color.IndianRed.Pastel($"abc {"123".Pastel(Color.Green)} efg")
```