### PR TITLE
Remove DISABLE_NEWLINE_AUTO_RETURN on Windows to fix unintended \n behaviour

### DIFF
--- a/src/ConsoleExtensions.cs
+++ b/src/ConsoleExtensions.cs
@@ -13,7 +13,6 @@
     {
         private const int  STD_OUTPUT_HANDLE                     = -11;
         private const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
-        private const uint DISABLE_NEWLINE_AUTO_RETURN        = 0x0008;
 
         [DllImport("kernel32.dll")]
         private static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
@@ -119,7 +118,7 @@
                 var iStdOut =   GetStdHandle(STD_OUTPUT_HANDLE);
 
                 var enable  =   GetConsoleMode(iStdOut, out var outConsoleMode)
-                             && SetConsoleMode(iStdOut, outConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN);
+                             && SetConsoleMode(iStdOut, outConsoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
             }
 
 

--- a/src/Pastel.csproj
+++ b/src/Pastel.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Users\Gabriel\Documents\Visual Studio 2017\Projects\2018\Pastel\src\Pastel.xml</DocumentationFile>
+    <DocumentationFile>./Pastel.xml</DocumentationFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Because `DISABLE_NEWLINE_AUTO_RETURN` is set on Windows systems the behaviour of `\n` is changed so it no longer outputs Carriage Return characters and only outputs Line Feeds. I suspect this is unintended behaviour for Pastel as code such as
```csharp
Console.WriteLine(Output.BrightGreen("Hello World!\nThis is an example of a bug!"));
```
renders as
![image](https://user-images.githubusercontent.com/5931310/62833926-e1460480-bc3d-11e9-9e1a-e2bf13e94145.png)
There's a good discussion of this property here which seems to suggest it's only intended for us on some very specific (emacs) circumstances.

Cheers!