### PR TITLE
Added a Source Generator for Extension Methods for simple types to call Pastel() without ToString().

### DIFF
--- a/Pastel.ExtensionsGenerator/DocumentationFromXmlFile.cs
+++ b/Pastel.ExtensionsGenerator/DocumentationFromXmlFile.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace SimpleTypesExtensionsGenerator;
+
+public sealed class DocumentationFromXmlFile
+{
+    private readonly XDocument? xdoc;
+
+    public DocumentationFromXmlFile(Compilation compilation)
+    {
+        var runtimeRef = compilation.References
+                                    .Select(compilation.GetAssemblyOrModuleSymbol)
+                                    .OfType<IAssemblySymbol>()
+                                    .FirstOrDefault(a => a.Name == "System.Runtime");
+
+        if (runtimeRef == null) return;
+
+        var referencePath = compilation.References
+                                       .FirstOrDefault(r =>
+                                       {
+                                           var asm = compilation.GetAssemblyOrModuleSymbol(r) as IAssemblySymbol;
+                                           return asm?.Name == "System.Runtime";
+                                       })
+                                       ?.Display;
+
+        if (string.IsNullOrEmpty(referencePath)) return;
+
+        try
+        {
+            var xmlPath = Path.ChangeExtension(referencePath, ".xml");
+            xdoc = XDocument.Load(xmlPath);
+        }
+        catch
+        {
+
+        }
+    }
+
+    public string? GetDocumentationForBclMethod(IMethodSymbol method)
+    {
+        if (xdoc is null) return null;
+
+        var docId = method.GetDocumentationCommentId();
+
+        if (docId is null) return null;
+
+        try
+        {
+            var member = xdoc.Descendants("member")
+                             .FirstOrDefault(m => string.Equals(m.Attribute("name")?.Value, docId, StringComparison.Ordinal));
+
+            return member?.ToString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/Pastel.ExtensionsGenerator/Pastel.ExtensionsGenerator.csproj
+++ b/Pastel.ExtensionsGenerator/Pastel.ExtensionsGenerator.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <RootNamespace>SimpleTypesExtensionsGenerator</RootNamespace>
+        <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+        <DevelopmentDependency>true</DevelopmentDependency>
+        <NoPackageAnalysis>true</NoPackageAnalysis>
+        <IncludeSymbols>false</IncludeSymbols>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" PrivateAssets="all" />
+    </ItemGroup>
+
+    <Target Name="IncludeAnalyzer" BeforeTargets="_GetPackageFiles">
+        <ItemGroup>
+            <None Include="$(OutputPath)$(TargetFileName)" Pack="true" PackagePath="analyzers\dotnet\cs\$(TargetFileName)" Visible="false" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="SuppressFrameworkReferences" BeforeTargets="_GetPackageFiles">
+        <ItemGroup>
+            <_PackageFilesToExclude Include="@(_TargetPathsToSymbols)" />
+        </ItemGroup>
+    </Target>
+
+</Project>

--- a/Pastel.ExtensionsGenerator/Pastel.ExtensionsGenerator.csproj
+++ b/Pastel.ExtensionsGenerator/Pastel.ExtensionsGenerator.csproj
@@ -12,6 +12,7 @@
         <DevelopmentDependency>true</DevelopmentDependency>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <IncludeSymbols>false</IncludeSymbols>
+        <AssemblyName>Pastel.ExtensionsGenerator</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
+++ b/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
@@ -155,6 +155,9 @@ public sealed class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
         sb.AppendLine();
         sb.AppendLine("namespace Pastel");
         sb.AppendLine("{");
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Extension methods for simple types to call Pastel() without ToString().");
+        sb.AppendLine("    /// </summary>");
         sb.AppendLine("    public static class GeneratedExtensions");
         sb.AppendLine("    {");
 

--- a/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
+++ b/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
@@ -98,8 +98,7 @@ public sealed class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
                                     Name = p.Name,
                                     Type = p.Type.ToDisplayString(),
                                     HasDefaultValue = p.HasExplicitDefaultValue,
-                                    DefaultValue = p.HasExplicitDefaultValue ? FormatDefaultValue(p.ExplicitDefaultValue) : null,
-                                    Xml = p.GetDocumentationCommentXml(expandIncludes: true)
+                                    DefaultValue = p.HasExplicitDefaultValue ? FormatDefaultValue(p.ExplicitDefaultValue) : null
                                 }).ToList(),
                                 Xml = method.GetDocumentationCommentXml(expandIncludes: true)
                             });
@@ -133,8 +132,7 @@ public sealed class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
                                                Name = p.Name,
                                                Type = p.Type.ToDisplayString(),
                                                HasDefaultValue = p.HasExplicitDefaultValue,
-                                               DefaultValue = p.HasExplicitDefaultValue ? FormatDefaultValue(p.ExplicitDefaultValue) : null,
-                                               Xml = p.GetDocumentationCommentXml(expandIncludes: true)
+                                               DefaultValue = p.HasExplicitDefaultValue ? FormatDefaultValue(p.ExplicitDefaultValue) : null
                                            })
                                            .ToList(),
                         Xml = method.GetDocumentationCommentXml(expandIncludes: true)
@@ -318,7 +316,6 @@ public sealed class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
         public string Type { get; set; } = string.Empty;
         public bool HasDefaultValue { get; set; }
         public string? DefaultValue { get; set; }
-        public string? Xml { get; set; }
     }
 
     private sealed class XmlDoc

--- a/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
+++ b/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis;
 namespace SimpleTypesExtensionsGenerator;
 
 [Generator]
-public class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
+public sealed class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
 {
     private static readonly string[] TargetTypes =
         [
@@ -293,7 +293,7 @@ public class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
         }
     }
 
-    private class ExtensionMethodInfo
+    private sealed class ExtensionMethodInfo
     {
         public string MethodName { get; set; } = string.Empty;
         public string ReturnType { get; set; } = string.Empty;
@@ -301,14 +301,14 @@ public class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
         public string? Xml { get; set; }
     }
 
-    private class ToStringMethodInfo
+    private sealed class ToStringMethodInfo
     {
         public string TargetType { get; set; } = string.Empty;
         public List<ParameterInfo> Parameters { get; set; } = [];
         public string? Xml { get; set; }
     }
 
-    private class ParameterInfo
+    private sealed class ParameterInfo
     {
         public string Name { get; set; } = string.Empty;
         public string Type { get; set; } = string.Empty;

--- a/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
+++ b/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
@@ -361,13 +361,11 @@ public sealed class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
 
             if (Returns.Count > 0)
             {
-                sb.AppendLine($"{indent}/// <returns>");
                 foreach (var line in Returns.Select(s => s.Split(["\r\n", "\n"], StringSplitOptions.None))
                                             .SelectMany(lines => lines))
                 {
                     sb.AppendLine($"{indent}/// {line}");
                 }
-                sb.AppendLine($"{indent}/// </returns>");
             }
 
             return sb.ToString().TrimEnd();

--- a/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
+++ b/Pastel.ExtensionsGenerator/SimpleTypesExtensionsSourceGenerator.cs
@@ -1,0 +1,366 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace SimpleTypesExtensionsGenerator;
+
+[Generator]
+public class SimpleTypesExtensionsSourceGenerator : ISourceGenerator
+{
+    private static readonly string[] TargetTypes =
+        [
+            "bool",
+            "byte",
+            "char",
+            "decimal",
+            "double",
+            "float",
+            "int",
+            "long",
+            "sbyte",
+            "short",
+            "uint",
+            "ulong",
+            "ushort"
+        ];
+
+    public void Initialize(GeneratorInitializationContext context) { }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        try
+        {
+            IAssemblySymbol? pastelAssembly;
+
+            if (context.Compilation.AssemblyName == "Pastel")
+            {
+                pastelAssembly = context.Compilation.Assembly;
+            }
+            else
+            {
+                pastelAssembly = context.Compilation.SourceModule.ReferencedAssemblySymbols
+                                        .FirstOrDefault(a => a.Name == "Pastel");
+            }
+
+            if (pastelAssembly == null) return;
+
+            var stringExtensions = FindStringExtensionMethods(pastelAssembly);
+
+            if (!stringExtensions.Any()) return;
+
+            var toStringMethods = FindToStringMethods(context.Compilation);
+            var generatedCode = GenerateCombinedExtensions(stringExtensions, toStringMethods);
+
+            context.AddSource("PastelExtensions.g.cs", generatedCode);
+        }
+        catch (Exception ex)
+        {
+            var diagnostic = Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    "PEG001",
+                    "PastelExtensionsGenerator Error",
+                    $"Error in PastelExtensionsGenerator: {ex.Message}",
+                    "PastelExtensionsGenerator",
+                    DiagnosticSeverity.Warning,
+                    true),
+                Location.None);
+
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+
+    private static List<ExtensionMethodInfo> FindStringExtensionMethods(IAssemblySymbol pastelAssembly)
+    {
+        var extensions = new List<ExtensionMethodInfo>();
+
+        foreach (var module in pastelAssembly.Modules)
+        {
+            foreach (var ns in GetAllNamespaces(module.GlobalNamespace))
+            {
+                foreach (var type in ns.GetTypeMembers())
+                {
+                    if (!type.IsStatic) continue;
+
+                    foreach (var member in type.GetMembers())
+                    {
+                        if (member is IMethodSymbol { IsExtensionMethod: true, Parameters.Length: > 0 } method &&
+                            method.Parameters[0].Type.SpecialType == SpecialType.System_String)
+                        {
+                            extensions.Add(new ExtensionMethodInfo
+                            {
+                                MethodName = method.Name,
+                                ReturnType = method.ReturnType.ToDisplayString(),
+                                Parameters = method.Parameters.Skip(1).Select(p => new ParameterInfo
+                                {
+                                    Name = p.Name,
+                                    Type = p.Type.ToDisplayString(),
+                                    HasDefaultValue = p.HasExplicitDefaultValue,
+                                    DefaultValue = p.HasExplicitDefaultValue ? FormatDefaultValue(p.ExplicitDefaultValue) : null,
+                                    Xml = p.GetDocumentationCommentXml(expandIncludes: true)
+                                }).ToList(),
+                                Xml = method.GetDocumentationCommentXml(expandIncludes: true)
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        return extensions;
+    }
+
+    private static List<ToStringMethodInfo> FindToStringMethods(Compilation compilation)
+    {
+        var toStringMethods = new List<ToStringMethodInfo>();
+
+        foreach (var targetType in TargetTypes)
+        {
+            var typeSymbol = compilation.GetSpecialType(GetSpecialType(targetType));
+
+            foreach (var member in typeSymbol.GetMembers("ToString"))
+            {
+                if (member is IMethodSymbol { IsStatic: false } method)
+                {
+                    toStringMethods.Add(new ToStringMethodInfo
+                    {
+                        TargetType = targetType,
+                        Parameters = method.Parameters
+                                           .Select(p => new ParameterInfo
+                                           {
+                                               Name = p.Name,
+                                               Type = p.Type.ToDisplayString(),
+                                               HasDefaultValue = p.HasExplicitDefaultValue,
+                                               DefaultValue = p.HasExplicitDefaultValue ? FormatDefaultValue(p.ExplicitDefaultValue) : null,
+                                               Xml = p.GetDocumentationCommentXml(expandIncludes: true)
+                                           })
+                                           .ToList(),
+                        Xml = method.GetDocumentationCommentXml(expandIncludes: true)
+                    });
+                }
+            }
+        }
+
+        return toStringMethods;
+    }
+
+    private static string GenerateCombinedExtensions(List<ExtensionMethodInfo> stringExtensions, List<ToStringMethodInfo> toStringMethods)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Drawing;");
+        sb.AppendLine();
+        sb.AppendLine("namespace Pastel");
+        sb.AppendLine("{");
+        sb.AppendLine("    public static class GeneratedExtensions");
+        sb.AppendLine("    {");
+
+        foreach (var stringExt in stringExtensions)
+        {
+            foreach (var toString in toStringMethods)
+            {
+                GenerateCombinedMethod(sb, stringExt, toString);
+            }
+        }
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private static void GenerateCombinedMethod(StringBuilder sb, ExtensionMethodInfo stringExt, ToStringMethodInfo toString)
+    {
+        var allParams = new List<ParameterInfo>();
+        allParams.AddRange(stringExt.Parameters);
+        allParams.AddRange(toString.Parameters);
+
+        allParams = allParams
+                    .OrderBy(p => p.HasDefaultValue)
+                    .ToList();
+
+        var xmlDoc = new XmlDoc();
+        LoadXmlDocumentation(toString.Xml, xmlDoc, toString.Parameters);
+        LoadXmlDocumentation(stringExt.Xml, xmlDoc, stringExt.Parameters);
+        sb.AppendLine(xmlDoc.ToString());
+
+        sb.AppendLine(
+            $"        public static {stringExt.ReturnType} {stringExt.MethodName}(this {toString.TargetType} value{(allParams.Any() ? ", " : "")}{string.Join(", ", allParams.Select(FormatParameter))})");
+        sb.AppendLine("        {");
+
+        var toStringCall = toString.Parameters.Any()
+            ? $"value.ToString({string.Join(", ", toString.Parameters.Select(p => p.Name))})"
+            : "value.ToString()";
+
+        var pastelCall = stringExt.Parameters.Any()
+            ? $".{stringExt.MethodName}({string.Join(", ", stringExt.Parameters.Select(p => p.Name))})"
+            : $".{stringExt.MethodName}()";
+
+        sb.AppendLine($"            return {toStringCall}{pastelCall};");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+    }
+
+    private static void LoadXmlDocumentation(string? xmlStr, XmlDoc xmlDoc, List<ParameterInfo> parameters)
+    {
+        if (string.IsNullOrEmpty(xmlStr)) return;
+
+        var xmDocument = XDocument.Parse(xmlStr);
+        var xmlMember = xmDocument.Element("member");
+
+        if (xmlMember != null)
+        {
+            var summary = xmlMember.Element("summary")?.Value.Trim();
+            if (!string.IsNullOrEmpty(summary)) xmlDoc.Summary.Add(summary!);
+
+            var returns = xmlMember.Element("returns");
+            if (returns != null) xmlDoc.Returns.Add(returns.ToString());
+
+            xmlDoc.Parameters.AddRange(xmlMember.Elements("param")
+                                                .Where(p => parameters.Select(p => p.Name).Contains(p.Attribute("name")?.Value))
+                                                .Select(p => p.ToString())
+                                                .Where(s => !string.IsNullOrEmpty(s)));
+        }
+    }
+
+    private static string FormatParameter(ParameterInfo param)
+    {
+        var result = $"{param.Type} {param.Name}";
+
+        if (param.HasDefaultValue) result = $"{result} = {param.DefaultValue}";
+
+        return result;
+    }
+
+    private static string FormatDefaultValue(object? value)
+    {
+        return value switch
+        {
+            null => "null",
+            string str => $"\"{str}\"",
+            bool b => b ? "true" : "false",
+            char c => $"'{c}'",
+            byte by => $"{by}",
+            sbyte sb => $"{sb}",
+            short s => $"{s}",
+            ushort us => $"{us}",
+            int i => $"{i}",
+            uint ui => $"{ui}u",
+            long l => $"{l}L",
+            ulong ul => $"{ul}UL",
+            float f => $"{f}f",
+            double d => $"{d}d",
+            decimal m => $"{m}m",
+            _ => value.ToString() ?? "null"
+        };
+    }
+
+    private static SpecialType GetSpecialType(string typeName)
+    {
+        return typeName switch
+        {
+            "bool" => SpecialType.System_Boolean,
+            "byte" => SpecialType.System_Byte,
+            "char" => SpecialType.System_Char,
+            "decimal" => SpecialType.System_Decimal,
+            "double" => SpecialType.System_Double,
+            "float" => SpecialType.System_Single,
+            "int" => SpecialType.System_Int32,
+            "long" => SpecialType.System_Int64,
+            "sbyte" => SpecialType.System_SByte,
+            "short" => SpecialType.System_Int16,
+            "uint" => SpecialType.System_UInt32,
+            "ulong" => SpecialType.System_UInt64,
+            "ushort" => SpecialType.System_UInt16,
+            _ => SpecialType.None
+        };
+    }
+
+    private static IEnumerable<INamespaceSymbol> GetAllNamespaces(INamespaceSymbol root)
+    {
+        yield return root;
+        foreach (var child in root.GetNamespaceMembers())
+        {
+            foreach (var nested in GetAllNamespaces(child))
+            {
+                yield return nested;
+            }
+        }
+    }
+
+    private class ExtensionMethodInfo
+    {
+        public string MethodName { get; set; } = string.Empty;
+        public string ReturnType { get; set; } = string.Empty;
+        public List<ParameterInfo> Parameters { get; set; } = [];
+        public string? Xml { get; set; }
+    }
+
+    private class ToStringMethodInfo
+    {
+        public string TargetType { get; set; } = string.Empty;
+        public List<ParameterInfo> Parameters { get; set; } = [];
+        public string? Xml { get; set; }
+    }
+
+    private class ParameterInfo
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public bool HasDefaultValue { get; set; }
+        public string? DefaultValue { get; set; }
+        public string? Xml { get; set; }
+    }
+
+    private sealed class XmlDoc
+    {
+        public List<string> Summary { get; set; } = [];
+        public List<string> Returns { get; set; } = [];
+        public List<string> Parameters { get; set; } = [];
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            if (Summary.Count > 0)
+            {
+                sb.AppendLine("/// <summary>");
+
+                for (var i = 0; i < Summary.Count; i++)
+                {
+                    var s = Summary[i];
+                    sb.AppendLine($"/// {s}");
+                    if (i < Summary.Count - 1) sb.AppendLine("/// <br/>");
+                }
+
+                sb.AppendLine("/// </summary>");
+            }
+
+            sb.AppendLine("/// <param name=\"value\">The value to convert.</param>");
+
+            foreach (var line in Parameters.Select(s => s.Split(["\r\n", "\n"], StringSplitOptions.None))
+                                           .SelectMany(lines => lines))
+            {
+                sb.AppendLine($"/// {line}");
+            }
+
+            if (Returns.Count > 0)
+            {
+                sb.AppendLine("/// <returns>");
+                foreach (var line in Returns.Select(s => s.Split(["\r\n", "\n"], StringSplitOptions.None))
+                                            .SelectMany(lines => lines))
+                {
+                    sb.AppendLine($"/// {line}");
+                }
+                sb.AppendLine("/// </returns>");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Pastel.sln
+++ b/Pastel.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pastel", "src\Pastel.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pastel.Tests", "tests\Pastel.Tests\Pastel.Tests.csproj", "{3ED5EFFF-2C4B-4D83-87B3-8AC08943CA68}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pastel.ExtensionsGenerator", "Pastel.ExtensionsGenerator\Pastel.ExtensionsGenerator.csproj", "{38D27B01-B6F6-466A-9E36-CAA35DB396A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{3ED5EFFF-2C4B-4D83-87B3-8AC08943CA68}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3ED5EFFF-2C4B-4D83-87B3-8AC08943CA68}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3ED5EFFF-2C4B-4D83-87B3-8AC08943CA68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38D27B01-B6F6-466A-9E36-CAA35DB396A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38D27B01-B6F6-466A-9E36-CAA35DB396A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38D27B01-B6F6-466A-9E36-CAA35DB396A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38D27B01-B6F6-466A-9E36-CAA35DB396A1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Pastel.csproj
+++ b/src/Pastel.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Authors>Gabriel Bider</Authors>
     <PackageTags>console colour color colors colours colourful colorful colourize colorize ansi NO_COLOR</PackageTags>
@@ -27,6 +28,20 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Pastel.Tests</_Parameter1>
     </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pastel.ExtensionsGenerator\Pastel.ExtensionsGenerator.csproj">
+      <OutputItemType>Analyzer</OutputItemType>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Pack>true</Pack>
+      <PackagePath>analyzers\dotnet\cs</PackagePath>
+      <PrivateAssets>none</PrivateAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build\Pastel.targets" Pack="true" PackagePath="build\" />
   </ItemGroup>
 
 </Project>

--- a/src/Pastel.csproj
+++ b/src/Pastel.csproj
@@ -15,6 +15,14 @@
     <PackageReleaseNotes>v7.0.0 Use terminal theme-defined ANSI base colors as default for the ConsoleColor overload</PackageReleaseNotes>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DocumentationFile>bin\Release\Pastel.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DocumentationFile>bin\Debug\Pastel.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Memory" Version="4.6.3" />

--- a/src/build/Pastel.targets
+++ b/src/build/Pastel.targets
@@ -1,0 +1,6 @@
+<Project>
+    <ItemGroup Condition="'$(MSBuildProjectName)' != 'Pastel' and '$(MSBuildProjectName)' != 'Pastel.ExtensionsGenerator'">
+        <Analyzer Include="$(MSBuildThisFileDirectory)..\analyzers\dotnet\cs\Pastel.ExtensionsGenerator.dll"
+                  Condition="Exists('$(MSBuildThisFileDirectory)..\analyzers\dotnet\cs\Pastel.ExtensionsGenerator.dll')" />
+    </ItemGroup>
+</Project>

--- a/tests/Pastel.Tests/SimpleTypesExtensionsSourceGeneratorTests.cs
+++ b/tests/Pastel.Tests/SimpleTypesExtensionsSourceGeneratorTests.cs
@@ -1,0 +1,330 @@
+﻿using System;
+using System.Globalization;
+using Xunit;
+
+namespace Pastel.Tests
+{
+    public class SimpleTypesExtensionsSourceGeneratorTests
+    {
+        [Theory]
+        [InlineData(true, ConsoleColor.Black)]
+        [InlineData(true, ConsoleColor.DarkRed)]
+        [InlineData(true, ConsoleColor.DarkGreen)]
+        [InlineData(true, ConsoleColor.DarkYellow)]
+        [InlineData(true, ConsoleColor.DarkBlue)]
+        [InlineData(true, ConsoleColor.DarkMagenta)]
+        [InlineData(true, ConsoleColor.DarkCyan)]
+        [InlineData(true, ConsoleColor.Gray)]
+        [InlineData(true, ConsoleColor.DarkGray)]
+        [InlineData(true, ConsoleColor.Red)]
+        [InlineData(true, ConsoleColor.Green)]
+        [InlineData(true, ConsoleColor.Yellow)]
+        [InlineData(true, ConsoleColor.Blue)]
+        [InlineData(true, ConsoleColor.Magenta)]
+        [InlineData(true, ConsoleColor.Cyan)]
+        [InlineData(true, ConsoleColor.White)]
+        public void BoolToStringTest(bool value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+        }
+
+        [Theory]
+        [InlineData(128, ConsoleColor.Black)]
+        [InlineData(128, ConsoleColor.DarkRed)]
+        [InlineData(128, ConsoleColor.DarkGreen)]
+        [InlineData(128, ConsoleColor.DarkYellow)]
+        [InlineData(128, ConsoleColor.DarkBlue)]
+        [InlineData(128, ConsoleColor.DarkMagenta)]
+        [InlineData(128, ConsoleColor.DarkCyan)]
+        [InlineData(128, ConsoleColor.Gray)]
+        [InlineData(128, ConsoleColor.DarkGray)]
+        [InlineData(128, ConsoleColor.Red)]
+        [InlineData(128, ConsoleColor.Green)]
+        [InlineData(128, ConsoleColor.Yellow)]
+        [InlineData(128, ConsoleColor.Blue)]
+        [InlineData(128, ConsoleColor.Magenta)]
+        [InlineData(128, ConsoleColor.Cyan)]
+        [InlineData(128, ConsoleColor.White)]
+        public void ByteToStringTest(byte value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData('A', ConsoleColor.Black)]
+        [InlineData('A', ConsoleColor.DarkRed)]
+        [InlineData('A', ConsoleColor.DarkGreen)]
+        [InlineData('A', ConsoleColor.DarkYellow)]
+        [InlineData('A', ConsoleColor.DarkBlue)]
+        [InlineData('A', ConsoleColor.DarkMagenta)]
+        [InlineData('A', ConsoleColor.DarkCyan)]
+        [InlineData('A', ConsoleColor.Gray)]
+        [InlineData('A', ConsoleColor.DarkGray)]
+        [InlineData('A', ConsoleColor.Red)]
+        [InlineData('A', ConsoleColor.Green)]
+        [InlineData('A', ConsoleColor.Yellow)]
+        [InlineData('A', ConsoleColor.Blue)]
+        [InlineData('A', ConsoleColor.Magenta)]
+        [InlineData('A', ConsoleColor.Cyan)]
+        [InlineData('A', ConsoleColor.White)]
+        public void CharToStringTest(char value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+        }
+
+        [Theory]
+        [InlineData(615.239182, ConsoleColor.Black)]
+        [InlineData(615.239182, ConsoleColor.DarkRed)]
+        [InlineData(615.239182, ConsoleColor.DarkGreen)]
+        [InlineData(615.239182, ConsoleColor.DarkYellow)]
+        [InlineData(615.239182, ConsoleColor.DarkBlue)]
+        [InlineData(615.239182, ConsoleColor.DarkMagenta)]
+        [InlineData(615.239182, ConsoleColor.DarkCyan)]
+        [InlineData(615.239182, ConsoleColor.Gray)]
+        [InlineData(615.239182, ConsoleColor.DarkGray)]
+        [InlineData(615.239182, ConsoleColor.Red)]
+        [InlineData(615.239182, ConsoleColor.Green)]
+        [InlineData(615.239182, ConsoleColor.Yellow)]
+        [InlineData(615.239182, ConsoleColor.Blue)]
+        [InlineData(615.239182, ConsoleColor.Magenta)]
+        [InlineData(615.239182, ConsoleColor.Cyan)]
+        [InlineData(615.239182, ConsoleColor.White)]
+        public void DecimalToStringTest(decimal value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(615.239182, ConsoleColor.Black)]
+        [InlineData(615.239182, ConsoleColor.DarkRed)]
+        [InlineData(615.239182, ConsoleColor.DarkGreen)]
+        [InlineData(615.239182, ConsoleColor.DarkYellow)]
+        [InlineData(615.239182, ConsoleColor.DarkBlue)]
+        [InlineData(615.239182, ConsoleColor.DarkMagenta)]
+        [InlineData(615.239182, ConsoleColor.DarkCyan)]
+        [InlineData(615.239182, ConsoleColor.Gray)]
+        [InlineData(615.239182, ConsoleColor.DarkGray)]
+        [InlineData(615.239182, ConsoleColor.Red)]
+        [InlineData(615.239182, ConsoleColor.Green)]
+        [InlineData(615.239182, ConsoleColor.Yellow)]
+        [InlineData(615.239182, ConsoleColor.Blue)]
+        [InlineData(615.239182, ConsoleColor.Magenta)]
+        [InlineData(615.239182, ConsoleColor.Cyan)]
+        [InlineData(615.239182, ConsoleColor.White)]
+        public void DoubleToStringTest(double value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(615.239182f, ConsoleColor.Black)]
+        [InlineData(615.239182f, ConsoleColor.DarkRed)]
+        [InlineData(615.239182f, ConsoleColor.DarkGreen)]
+        [InlineData(615.239182f, ConsoleColor.DarkYellow)]
+        [InlineData(615.239182f, ConsoleColor.DarkBlue)]
+        [InlineData(615.239182f, ConsoleColor.DarkMagenta)]
+        [InlineData(615.239182f, ConsoleColor.DarkCyan)]
+        [InlineData(615.239182f, ConsoleColor.Gray)]
+        [InlineData(615.239182f, ConsoleColor.DarkGray)]
+        [InlineData(615.239182f, ConsoleColor.Red)]
+        [InlineData(615.239182f, ConsoleColor.Green)]
+        [InlineData(615.239182f, ConsoleColor.Yellow)]
+        [InlineData(615.239182f, ConsoleColor.Blue)]
+        [InlineData(615.239182f, ConsoleColor.Magenta)]
+        [InlineData(615.239182f, ConsoleColor.Cyan)]
+        [InlineData(615.239182f, ConsoleColor.White)]
+        public void FloatToStringTest(float value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(615239, ConsoleColor.Black)]
+        [InlineData(615239, ConsoleColor.DarkRed)]
+        [InlineData(615239, ConsoleColor.DarkGreen)]
+        [InlineData(615239, ConsoleColor.DarkYellow)]
+        [InlineData(615239, ConsoleColor.DarkBlue)]
+        [InlineData(615239, ConsoleColor.DarkMagenta)]
+        [InlineData(615239, ConsoleColor.DarkCyan)]
+        [InlineData(615239, ConsoleColor.Gray)]
+        [InlineData(615239, ConsoleColor.DarkGray)]
+        [InlineData(615239, ConsoleColor.Red)]
+        [InlineData(615239, ConsoleColor.Green)]
+        [InlineData(615239, ConsoleColor.Yellow)]
+        [InlineData(615239, ConsoleColor.Blue)]
+        [InlineData(615239, ConsoleColor.Magenta)]
+        [InlineData(615239, ConsoleColor.Cyan)]
+        [InlineData(615239, ConsoleColor.White)]
+        public void IntToStringTest(int value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(615239, ConsoleColor.Black)]
+        [InlineData(615239, ConsoleColor.DarkRed)]
+        [InlineData(615239, ConsoleColor.DarkGreen)]
+        [InlineData(615239, ConsoleColor.DarkYellow)]
+        [InlineData(615239, ConsoleColor.DarkBlue)]
+        [InlineData(615239, ConsoleColor.DarkMagenta)]
+        [InlineData(615239, ConsoleColor.DarkCyan)]
+        [InlineData(615239, ConsoleColor.Gray)]
+        [InlineData(615239, ConsoleColor.DarkGray)]
+        [InlineData(615239, ConsoleColor.Red)]
+        [InlineData(615239, ConsoleColor.Green)]
+        [InlineData(615239, ConsoleColor.Yellow)]
+        [InlineData(615239, ConsoleColor.Blue)]
+        [InlineData(615239, ConsoleColor.Magenta)]
+        [InlineData(615239, ConsoleColor.Cyan)]
+        [InlineData(615239, ConsoleColor.White)]
+        public void LongToStringTest(long value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(127, ConsoleColor.Black)]
+        [InlineData(127, ConsoleColor.DarkRed)]
+        [InlineData(127, ConsoleColor.DarkGreen)]
+        [InlineData(127, ConsoleColor.DarkYellow)]
+        [InlineData(127, ConsoleColor.DarkBlue)]
+        [InlineData(127, ConsoleColor.DarkMagenta)]
+        [InlineData(127, ConsoleColor.DarkCyan)]
+        [InlineData(127, ConsoleColor.Gray)]
+        [InlineData(127, ConsoleColor.DarkGray)]
+        [InlineData(127, ConsoleColor.Red)]
+        [InlineData(127, ConsoleColor.Green)]
+        [InlineData(127, ConsoleColor.Yellow)]
+        [InlineData(127, ConsoleColor.Blue)]
+        [InlineData(127, ConsoleColor.Magenta)]
+        [InlineData(127, ConsoleColor.Cyan)]
+        [InlineData(127, ConsoleColor.White)]
+        public void SbyteToStringTest(sbyte value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(3127, ConsoleColor.Black)]
+        [InlineData(3127, ConsoleColor.DarkRed)]
+        [InlineData(3127, ConsoleColor.DarkGreen)]
+        [InlineData(3127, ConsoleColor.DarkYellow)]
+        [InlineData(3127, ConsoleColor.DarkBlue)]
+        [InlineData(3127, ConsoleColor.DarkMagenta)]
+        [InlineData(3127, ConsoleColor.DarkCyan)]
+        [InlineData(3127, ConsoleColor.Gray)]
+        [InlineData(3127, ConsoleColor.DarkGray)]
+        [InlineData(3127, ConsoleColor.Red)]
+        [InlineData(3127, ConsoleColor.Green)]
+        [InlineData(3127, ConsoleColor.Yellow)]
+        [InlineData(3127, ConsoleColor.Blue)]
+        [InlineData(3127, ConsoleColor.Magenta)]
+        [InlineData(3127, ConsoleColor.Cyan)]
+        [InlineData(3127, ConsoleColor.White)]
+        public void ShortToStringTest(short value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(651321, ConsoleColor.Black)]
+        [InlineData(651321, ConsoleColor.DarkRed)]
+        [InlineData(651321, ConsoleColor.DarkGreen)]
+        [InlineData(651321, ConsoleColor.DarkYellow)]
+        [InlineData(651321, ConsoleColor.DarkBlue)]
+        [InlineData(651321, ConsoleColor.DarkMagenta)]
+        [InlineData(651321, ConsoleColor.DarkCyan)]
+        [InlineData(651321, ConsoleColor.Gray)]
+        [InlineData(651321, ConsoleColor.DarkGray)]
+        [InlineData(651321, ConsoleColor.Red)]
+        [InlineData(651321, ConsoleColor.Green)]
+        [InlineData(651321, ConsoleColor.Yellow)]
+        [InlineData(651321, ConsoleColor.Blue)]
+        [InlineData(651321, ConsoleColor.Magenta)]
+        [InlineData(651321, ConsoleColor.Cyan)]
+        [InlineData(651321, ConsoleColor.White)]
+        public void UintToStringTest(uint value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(95222651321, ConsoleColor.Black)]
+        [InlineData(95222651321, ConsoleColor.DarkRed)]
+        [InlineData(95222651321, ConsoleColor.DarkGreen)]
+        [InlineData(95222651321, ConsoleColor.DarkYellow)]
+        [InlineData(95222651321, ConsoleColor.DarkBlue)]
+        [InlineData(95222651321, ConsoleColor.DarkMagenta)]
+        [InlineData(95222651321, ConsoleColor.DarkCyan)]
+        [InlineData(95222651321, ConsoleColor.Gray)]
+        [InlineData(95222651321, ConsoleColor.DarkGray)]
+        [InlineData(95222651321, ConsoleColor.Red)]
+        [InlineData(95222651321, ConsoleColor.Green)]
+        [InlineData(95222651321, ConsoleColor.Yellow)]
+        [InlineData(95222651321, ConsoleColor.Blue)]
+        [InlineData(95222651321, ConsoleColor.Magenta)]
+        [InlineData(95222651321, ConsoleColor.Cyan)]
+        [InlineData(95222651321, ConsoleColor.White)]
+        public void UlongToStringTest(ulong value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+
+        [Theory]
+        [InlineData(6582, ConsoleColor.Black)]
+        [InlineData(6582, ConsoleColor.DarkRed)]
+        [InlineData(6582, ConsoleColor.DarkGreen)]
+        [InlineData(6582, ConsoleColor.DarkYellow)]
+        [InlineData(6582, ConsoleColor.DarkBlue)]
+        [InlineData(6582, ConsoleColor.DarkMagenta)]
+        [InlineData(6582, ConsoleColor.DarkCyan)]
+        [InlineData(6582, ConsoleColor.Gray)]
+        [InlineData(6582, ConsoleColor.DarkGray)]
+        [InlineData(6582, ConsoleColor.Red)]
+        [InlineData(6582, ConsoleColor.Green)]
+        [InlineData(6582, ConsoleColor.Yellow)]
+        [InlineData(6582, ConsoleColor.Blue)]
+        [InlineData(6582, ConsoleColor.Magenta)]
+        [InlineData(6582, ConsoleColor.Cyan)]
+        [InlineData(6582, ConsoleColor.White)]
+        public void UshortToStringTest(ushort value, ConsoleColor consoleColor)
+        {
+            Assert.Equal(value.ToString().Pastel(consoleColor), value.Pastel(consoleColor));
+            Assert.Equal(value.ToString("E").Pastel(consoleColor), value.Pastel(consoleColor, "E"));
+            Assert.Equal(value.ToString(new CultureInfo("fr-FR")).Pastel(consoleColor), value.Pastel(consoleColor, new CultureInfo("fr-FR")));
+            Assert.Equal(value.ToString("E4", new CultureInfo("en-US")).Pastel(consoleColor), value.Pastel(consoleColor, "E4", new CultureInfo("en-US")));
+        }
+    }
+}


### PR DESCRIPTION
All existing overloads of the ToString() method are generated.

The color can be applied to Primitive Types without first converting them to a string. Primitive Types: int, uint, long, ulong, short, ushort, byte, sbyte, float, double, decimal, bool, char.
```cs
int intValue = 123;
intValue.Pastel(ConsoleColor.Cyan);

bool boolValue = true;
boolValue.Pastel(ConsoleColor.Cyan);

float floatValue = 123.45f;
floatValue.Pastel(ConsoleColor.Cyan, "C0", CultureInfo.InvariantCulture);
```